### PR TITLE
replace TensorboardX with PyTorch builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@ Pytorch implementation for "Deep Learning for Case-Based Reasoning through Proto
 
 ## Requirements
 - Python 3.6.1
-- PyTorch 0.4.1
+- PyTorch 1.1.0 or higher
 - Torchvision 0.2.1
-- TensorboardX
 
 ## Usage
 

--- a/args.py
+++ b/args.py
@@ -47,7 +47,7 @@ def get_args():
     parser.add_argument('--save_path', default='./trained_models', type=str, help='Directory where models are saved')
 
     # Other
-    parser.add_argument('--log_dir', default='./logs', type=str, help='Directory where tensorboardX logs are saved')
+    parser.add_argument('--log_dir', default='./logs', type=str, help='Directory where tensorboard logs are saved')
     parser.add_argument('--log_iter', default=100, type=int, help='print frequency (default: 10)')
     parser.add_argument('--resume', default=False, type=str2bool, help='path to latest checkpoint (default: none)')
     parser.add_argument('--seed', default=123, type=int, help='seed for initializing training')

--- a/logger.py
+++ b/logger.py
@@ -3,10 +3,9 @@ import pdb
 import sys
 import time
 import torch
-import tensorboardX
-from tensorboardX import SummaryWriter
+from torch.utils.tensorboard import SummaryWriter
 
-class TensorboardXLogger:
+class TensorboardLogger:
     def __init__(self, start_epoch, log_iter, log_dir):
         self.log_iter = log_iter
         self.writer = SummaryWriter(log_dir=log_dir)

--- a/train.py
+++ b/train.py
@@ -5,8 +5,6 @@ import random
 import shutil
 import warnings
 import argparse
-import tensorboardX
-from tensorboardX import SummaryWriter
 
 import torch
 import torch.optim
@@ -20,7 +18,7 @@ from torch.utils.data import DataLoader
 from utils import *
 from models import CAE
 from args import get_args
-from logger import TensorboardXLogger
+from logger import TensorboardLogger
 
 use_cuda = torch.cuda.is_available()
 
@@ -121,7 +119,7 @@ def train(opts):
     model = model.to(device)
 
     # for logging
-    logger = TensorboardXLogger(opts.start_epoch, opts.log_iter, opts.log_dir)
+    logger = TensorboardLogger(opts.start_epoch, opts.log_iter, opts.log_dir)
     logger.set(['acc', 'loss', 'loss_class', 'loss_ae', 'loss_r1', 'loss_r2'])
     logger.n_iter = start_n_iter
 


### PR DESCRIPTION
Hey, there!
Thanks for the nice implementation. I noticed that since PyTorch v1.1.0 has native Tensorboard support, you can remove the TensorboardX dependency, leaving PyTorch and torchvision as the only dependencies.

I've tested this with Python 3.7.7, PyTorch v1.7.1 and torchvision 0.8.2